### PR TITLE
fix: Add missing plotly dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 scipy
 matplotlib
 pandas
+plotly


### PR DESCRIPTION
This commit adds `plotly` to the `requirements.txt` file.

The absence of this dependency was causing a `ModuleNotFoundError` on application startup, preventing the app from running. This change ensures that all required packages are installed when following the setup instructions.