### PR TITLE
fix: Add missing kaleido dependency for image export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scipy
 matplotlib
 pandas
 plotly
+kaleido


### PR DESCRIPTION
This commit adds the `kaleido` package to `requirements.txt`.

This package is required by Plotly for static image export functionality, such as the "Download Chart (PNG)" button. Its absence was causing an error when trying to use this feature.