### PR TITLE
fix: Add packages.txt for kaleido system dependencies

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,5 @@
+libgl1-mesa-glx
+libglib2.0-0
+libsm6
+libxext6
+libxrender-dev


### PR DESCRIPTION
This commit adds a `packages.txt` file to specify system-level libraries required for the Kaleido package to run in a containerized environment like Streamlit Cloud.

The absence of these libraries was causing a `RuntimeError` during image export, even after the `kaleido` Python package was installed. This file instructs the deployment environment to install the necessary dependencies via `apt-get`, resolving the issue.